### PR TITLE
Feature/sha256

### DIFF
--- a/maestro/aws/s3.py
+++ b/maestro/aws/s3.py
@@ -13,7 +13,7 @@ from botocore.client import Config
 from ..core import module
 
 
-def find_files(bucket, prefix, case_sensitive=True, connection=None, anonymous=True):
+def find_files(bucket, prefix, case_sensitive=True, connection=None, anonymous=True, sha256=False):
     """
     find_files will connect and return files found in bucket with prefix, all other keys are ignored.
 
@@ -22,7 +22,6 @@ def find_files(bucket, prefix, case_sensitive=True, connection=None, anonymous=T
     Returns a boto3 objectCollection containing matching files, or an empty collection. Will not return any non-file keys.
     Will raise a DownloadError with an appropriate error message when unable to return a collection.
     """
-
     s3client = None
     if connection is None:
         try:
@@ -51,13 +50,19 @@ def find_files(bucket, prefix, case_sensitive=True, connection=None, anonymous=T
         # Iterate over objects, and append only ones that match lower case and don't end with '/'
         for obj in remote_bucket.objects.all():
             if obj.key.lower().startswith(prefix.lower()) and not obj.key.endswith("/"):
-                objsum = s3client.get_object(Bucket=bucket, Key=obj.key)["ETag"][1:-1]
+                if sha256:
+                    objsum = s3client.head_object(Bucket=bucket, Key=obj.key, ChecksumMode='ENABLED')['ResponseMetadata']['HTTPHeaders']["x-amz-checksum-sha256"]
+                else:
+                    objsum = s3client.get_object(Bucket=bucket, Key=obj.key)["ETag"][1:-1]
                 files.append((obj, objsum))
     else:  # If we're case sensitive, just use the filter
         files = remote_bucket.objects.filter(Prefix=prefix)
         sum_files = list()
         for f in files:
-            objsum = s3client.get_object(Bucket=bucket, Key=f.key)["ETag"][1:-1]
+            if sha256:
+                objsum = s3client.head_object(Bucket=bucket, Key=f.key, ChecksumMode='ENABLED')['ResponseMetadata']['HTTPHeaders']["x-amz-checksum-sha256"]
+            else:
+                objsum = s3client.get_object_attributes(Bucket=bucket, Key=f.key, ObjectAttributes=['ETag'])[1:-1]
             sum_files.append((f, objsum))
         files = sum_files
 
@@ -256,7 +261,7 @@ read access.
             # Return value
             destination_files = list()
             # Loop through found files
-            for obj, checksum in find_files(self.bucket_name, self.prefix, case_sensitive=not self.case_insensitive, connection=s3, anonymous=self.anonymous):
+            for obj, checksum in find_files(self.bucket_name, self.prefix, case_sensitive=not self.case_insensitive, connection=s3, anonymous=self.anonymous, sha256=True):
                 if obj.key.endswith("/"):
                     continue
                 destination = self.destination_path

--- a/maestro/aws/s3.py
+++ b/maestro/aws/s3.py
@@ -207,6 +207,7 @@ read access.
         region = None
         source_url = None
         anonymous = None
+        sha256 = False
 
         def run(self, kwargs):
             if kwargs is not None and len(kwargs) > 0:
@@ -273,7 +274,7 @@ read access.
             # Return value
             destination_files = list()
             # Loop through found files
-            for obj, checksum in find_files(self.bucket_name, self.prefix, case_sensitive=not self.case_insensitive, connection=s3, anonymous=self.anonymous, sha256=True):
+            for obj, checksum in find_files(self.bucket_name, self.prefix, case_sensitive=not self.case_insensitive, connection=s3, anonymous=self.anonymous, sha256=self.sha256):
                 if obj.key.endswith("/"):
                     continue
                 destination = self.destination_path

--- a/maestro/tools/file.py
+++ b/maestro/tools/file.py
@@ -3,7 +3,7 @@ Maestro File Tools
 """
 
 import hashlib
-
+import base64
 
 def read_blocks(file, blocksize=1024):
     while True:
@@ -13,6 +13,37 @@ def read_blocks(file, blocksize=1024):
         else:
             return
 
+def sha256_simple(filename):
+    m = hashlib.sha256()
+    with open(filename, "rb") as f:
+        # Read and update hash string value in blocks of 4K
+        for byte_block in iter(lambda: f.read(8 * 1024 * 1024), b''):
+            m.update(byte_block)
+    return base64.b64encode(m.digest()).decode('utf-8')
+
+def sha256_multipart(file_path, chunk_size=16 * 1024 * 1024):
+    # chuck size of 16 mb works for our s3 downloads, multiplayer may change if smaller chuck sizes
+    sha256_hashes = []
+    with open(file_path, 'rb') as fp:
+        while True:
+            data = fp.read(chunk_size)
+            if not data:
+                break
+            sha256_hashes.append(hashlib.sha256(data))
+
+    if len(sha256_hashes) == 1:
+        return '"{}"'.format(sha256_hashes[0].hexdigest())
+
+    digests = b''.join(sha.digest() for sha in sha256_hashes)
+    digests_sha256 = hashlib.sha256(digests)
+    return '{}-{}'.format(base64.b64encode(digests_sha256.digest()).decode('utf-8'), len(sha256_hashes))
+
+def sha256_checksum(filename, checksum):
+    checksum_stripped = checksum[1:-1]  # strip quotes
+    if '-' in checksum_stripped:
+        return sha256_multipart(filename)
+    else:
+        return sha256_simple(filename)
 
 def md5_checksum(afile, blocksize=65536):
     with open(afile, "rb") as f:

--- a/maestro/tools/file.py
+++ b/maestro/tools/file.py
@@ -22,7 +22,7 @@ def sha256_simple(filename):
     return base64.b64encode(m.digest()).decode('utf-8')
 
 def sha256_multipart(file_path, chunk_size=16 * 1024 * 1024):
-    # chuck size of 16 mb works for our s3 downloads, multiplayer may change if smaller chuck sizes
+    # chuck size of 16 mb works for our s3 downloads, multiplier may change if smaller chuck sizes
     sha256_hashes = []
     with open(file_path, 'rb') as fp:
         while True:

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 from distutils.core import setup
 
 setup(name='MaestroOps',
-      version='0.8.8',
+      version='0.9.0',
       description='Python Automation Framework for Development Operations Teams',
       author='Signiant DevOps',
       author_email='devops@signiant.com',
       url='https://www.signiant.com',
       packages=find_packages(),
       license='MIT',
-      install_requires=['boto3>=1.0.0,<2']
+      install_requires=['boto3>=1.34.0,<2']
      )


### PR DESCRIPTION
This update allows for sha256 s3 checksums both standard and multipart s3 upload sums.  Will require SHA256 checksum to be available on all objects in the bucket.  Default behaviour including in AsyncDownloader is to compare etag and that has not changed.