### PR TITLE
Decrease boto3 requirements for older OSes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 from distutils.core import setup
 
 setup(name='MaestroOps',
-      version='0.9.0',
+      version='0.9.1',
       description='Python Automation Framework for Development Operations Teams',
       author='Signiant DevOps',
       author_email='devops@signiant.com',
       url='https://www.signiant.com',
       packages=find_packages(),
       license='MIT',
-      install_requires=['boto3>=1.34.0,<2']
+      install_requires=['boto3>=1.33.1,<1.34.0']
      )


### PR DESCRIPTION
This helped for older operating systems which could not see the latest boto3 packages, even with upgraded python.